### PR TITLE
Update "Play with it" url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@ A Lisp compiler and environment that runs in a browser.
 
 - [slip.lisperator.net](http://slip.lisperator.net/) for more information.
 - [A screencast at Vimeo](https://vimeo.com/42070553).
-- [Play with it](http://slip.lisperator.net/s/demo/?ide) (requires popups).
+- [Play with it](http://lisperator.net/s/slip/?ide) (requires popups).
 - [Follow me on Twitter](https://twitter.com/#!/mcbazon)


### PR DESCRIPTION
slip.lisperator.net now redirects to lisperator.net/slip, but the live demo link was broken.  This fixes it.
